### PR TITLE
bcm4354-bt.bbappend: Remove this obsolete .bbappend

### DIFF
--- a/recipes-bsp/bcm4354-bluetooth/bcm4354-bt.bbappend
+++ b/recipes-bsp/bcm4354-bluetooth/bcm4354-bt.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS_prepend_artik710 := "${THISDIR}/files:"
-
-SRC_URI_append_artik710 = " file://BCM4354_003.001.012.0301.0000_Samsung_Artik_TEST_ONLY.hcd"
-
-COMPATIBLE_MACHINE = "(artik5|artik10|artik710)"


### PR DESCRIPTION
It is replaced by the recipe in the broadcom-bluetooth directory

Signed-off-by: Florin Sarbu florin@resin.io
