### PR TITLE
linux-yocto-artik710.bb: Update to 4.4.71

### DIFF
--- a/recipes-kernel/linux/linux-yocto-artik710.bb
+++ b/recipes-kernel/linux/linux-yocto-artik710.bb
@@ -1,12 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-LINUX_VERSION = "4.4.19"
-SRC_URI = " \
-    git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=A710/v4.4 \
-    file://compile_mali_kernel_module_out_of_tree.patch \
-    file://DRM-nexell-Add-support-for-hdmi-1280x1024-60-resolut.patch \
-    "
-SRCREV = "b3337cbeced5c49415aa405a355d07bb99f6ed43"
+LINUX_VERSION = "4.4.71"
+SRC_URI = "git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=A710_os_3.1.0"
+SRCREV = "ca9c56b32397759e0629b618c5b05155aa31df97"
 
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc


### PR DESCRIPTION
The old revision we were using, b3337cbeced5c49415aa405a355d07bb99f6ed43,
isn't available anymore in the samsung kernel git tree. So we use this occasion
to switch to the kernel from Samsung 3.1.0 release for the Artik 710.

With this update we also remove compile_mali_kernel_module_out_of_tree.patch which
is not needed anymore and removed DRM-nexell-Add-support-for-hdmi-1280x1024-60-resolut.patch
which was merged upstream here:

https://github.com/SamsungARTIK/linux-artik/commit/fe277ef3cb82bf8227d418f82d88af5d118183c6

Signed-off-by: Florin Sarbu <florin@resin.io>